### PR TITLE
feat: update resource_request schema to require only one of resourceType and resourceName

### DIFF
--- a/staging/apps/resource_request/1.0/resource_request.schema.json
+++ b/staging/apps/resource_request/1.0/resource_request.schema.json
@@ -38,7 +38,21 @@
         "title": "Angeforderte Ressource",
         "description": "Eine angeforderte Ressource.",
         "type": "object",
-        "required": ["resourceRequestId", "resourceType", "resourceName"],
+        "required": ["resourceRequestId"],
+        "oneOf": [
+          {
+            "required": ["resourceType"],
+            "not": {
+              "required": ["resourceName"]
+            }
+          },
+          {
+            "required": ["resourceName"],
+            "not": {
+              "required": ["resourceType"]
+            }
+          }
+        ],
         "properties": {
           "resourceRequestId": {
             "title": "Resource Request ID",
@@ -143,12 +157,10 @@
     "requestedResources": [
       {
         "resourceRequestId": "10002003",
-        "resourceType": "KTW",
-        "resourceName": "KTW-1"
+        "resourceType": "KTW"
       },
       {
         "resourceRequestId": "10002005",
-        "resourceType": "RTW",
         "resourceName": "RTW-3"
       }
     ]

--- a/staging/apps/resource_request/1.0/resource_request.schema.json
+++ b/staging/apps/resource_request/1.0/resource_request.schema.json
@@ -40,18 +40,8 @@
         "type": "object",
         "required": ["resourceRequestId"],
         "oneOf": [
-          {
-            "required": ["resourceType"],
-            "not": {
-              "required": ["resourceName"]
-            }
-          },
-          {
-            "required": ["resourceName"],
-            "not": {
-              "required": ["resourceType"]
-            }
-          }
+          { "required": ["resourceType"] },
+          { "required": ["resourceName"] }
         ],
         "properties": {
           "resourceRequestId": {


### PR DESCRIPTION
- Es wurde eine oneOf-Einschränkung hinzugefügt, um sicherzustellen, dass genau eines der Felder resourceType oder resourceName vorhanden ist.
- Das Beispiel wurde aktualisiert, um beide gültigen Muster zu veranschaulichen.
- resourceRequestId bleibt für alle Ressourcenanfragen obligatorisch.

